### PR TITLE
jsAlertClose: change attaching the window.onLoad event 

### DIFF
--- a/Resources/views/FlashAlert/jsAlertClose.html.twig
+++ b/Resources/views/FlashAlert/jsAlertClose.html.twig
@@ -1,13 +1,10 @@
 <script type="text/javascript">
     // Pure JavaScript implementation for flash alerts
     var onLoad = function () {
-        console.log('foo');
         var elems = document.getElementById("ras-flash-alerts").getElementsByTagName('button');
-        console.log(elems);
         for (var i in elems) {
             if ((" " + elems[i].className + " ").indexOf("alert-close") > -1) {
                 elems[i].onclick = function () {
-                    console.log(this);
                     fadeout(this.parentNode);
                 };
             }

--- a/Resources/views/FlashAlert/jsAlertClose.html.twig
+++ b/Resources/views/FlashAlert/jsAlertClose.html.twig
@@ -1,10 +1,13 @@
 <script type="text/javascript">
     // Pure JavaScript implementation for flash alerts
-    window.onload = function () {
+    var onLoad = function () {
+        console.log('foo');
         var elems = document.getElementById("ras-flash-alerts").getElementsByTagName('button');
+        console.log(elems);
         for (var i in elems) {
             if ((" " + elems[i].className + " ").indexOf("alert-close") > -1) {
                 elems[i].onclick = function () {
+                    console.log(this);
                     fadeout(this.parentNode);
                 };
             }
@@ -24,4 +27,8 @@
             o -= 0.1;
         }, 25);
     };
+
+    if (window.attachEvent) {window.attachEvent('onload', onLoad);}
+    else if (window.addEventListener) {window.addEventListener('load', onLoad, false);}
+    else {document.addEventListener('load', onload, false);}
 </script>

--- a/Resources/views/FlashAlert/jsAlertClose.html.twig
+++ b/Resources/views/FlashAlert/jsAlertClose.html.twig
@@ -27,5 +27,5 @@
 
     if (window.attachEvent) {window.attachEvent('onload', onLoad);}
     else if (window.addEventListener) {window.addEventListener('load', onLoad, false);}
-    else {document.addEventListener('load', onload, false);}
+    else {document.addEventListener('load', onLoad, false);}
 </script>


### PR DESCRIPTION
Hi,

i had a problem in chrome that the close button of the flash massages not worked. After investigating the problem, i found out that window.onload was not fired.

After a little research i changed the event attachment like described here: https://ckon.wordpress.com/2008/07/25/stop-using-windowonload-in-javascript/