### PR TITLE
Update services.yml to fix YAML Parser exception

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,23 +3,23 @@ services:
     ras_flash_alert.alert_manager:
         class: Ras\Bundle\FlashAlertBundle\Model\AlertManager
         arguments:
-            session: @Session
+            session: "@Session"
 
     ras_flash_alert.alert_reporter:
         class: Ras\Bundle\FlashAlertBundle\Model\AlertReporter
         arguments:
-            alertManager: @ras_flash_alert.alert_manager
+            alertManager: "@ras_flash_alert.alert_manager"
 
     ras_flash_alert.alert_publisher:
         class: Ras\Bundle\FlashAlertBundle\Model\AlertPublisher
         arguments:
-            alertManager: @ras_flash_alert.alert_manager
+            alertManager: "@ras_flash_alert.alert_manager"
 
     # twig extensions
     ras_flash_alert.twig.flash_alerts_extension:
         class: Ras\Bundle\FlashAlertBundle\Twig\FlashAlertsExtension
         arguments:
-            container: @service_container
+            container: "@service_container"
         tags:
             - { name: twig.extension }
 
@@ -27,8 +27,8 @@ services:
     ras_flash_alert.templating.flash_alerts_helper:
         class: Ras\Bundle\FlashAlertBundle\Templating\Helper\FlashAlertsHelper
         arguments:
-            templating: @templating
-            alertPublisher: @ras_flash_alert.alert_publisher
-            options: %ras_flash_alerts.options%
+            templating: "@templating"
+            alertPublisher: "@ras_flash_alert.alert_publisher"
+            options: "%ras_flash_alerts.options%"
         tags:
             - { name: templating.helper, alias: flashAlerts }


### PR DESCRIPTION
Fixes "The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 6 (near "session: @Session").'"