### PR TITLE
fixed deprecated instances

### DIFF
--- a/Twig/FlashAlertsExtension.php
+++ b/Twig/FlashAlertsExtension.php
@@ -44,10 +44,10 @@ class FlashAlertsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'get_alert_publisher' => new \Twig_Function_Method($this, 'getAlertPublisher', array(
+            new \Twig_SimpleFunction('get_alert_publisher', array($this, 'getAlertPublisher'), array(
                 'is_safe'   =>  array('html')
             )),
-            'render_flash_alerts' => new \Twig_Function_Method($this, 'renderFlashAlerts', array(
+            new \Twig_SimpleFunction('render_flash_alerts', array($this, 'renderFlashAlerts'), array(
                 'is_safe'   =>  array('html')
             ))
         );


### PR DESCRIPTION
Fixed these errors:

```
Using an instance of "Twig_Function_Method" for function "render_flash_alerts" is deprecated since version 1.21. Use Twig_SimpleFunction instead: 3x
    2x in DefaultControllerTest::testIndex from BvWholesale\Bundle\AdminBundle\Tests\Controller
    1x in DefaultControllerTest::testIndex from BvWholesale\Bundle\CoreBundle\Tests\Controller

Using an instance of "Twig_Function_Method" for function "get_alert_publisher" is deprecated since version 1.21. Use Twig_SimpleFunction instead: 3x
    2x in DefaultControllerTest::testIndex from BvWholesale\Bundle\AdminBundle\Tests\Controller
    1x in DefaultControllerTest::testIndex from BvWholesale\Bundle\CoreBundle\Tests\Controller

The Twig_Function class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFunction instead: 1x
    1x in DefaultControllerTest::testIndex from BvWholesale\Bundle\AdminBundle\Tests\Controller

The Twig_Function_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFunction instead: 1x
    1x in DefaultControllerTest::testIndex from BvWholesale\Bundle\AdminBundle\Tests\Controller
```